### PR TITLE
Fix dupword linter issue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - containedctx
     - decorder # checks declaration order and count of types, constants, variables and functions
     - dogsled
+    - dupword # checks for duplicate words in the source code
     - durationcheck # checks for two durations multiplied together
     - errcheck
     - errname

--- a/spancheck.go
+++ b/spancheck.go
@@ -77,7 +77,7 @@ type spanVar struct {
 	vr   *types.Var
 }
 
-// runFunc checks if the the node is a function, has a span, and the span never has SetStatus set.
+// runFunc checks if the node is a function, has a span, and the span never has SetStatus set.
 func runFunc(pass *analysis.Pass, node ast.Node, config *Config) {
 	// copying https://cs.opensource.google/go/x/tools/+/master:go/analysis/passes/lostcancel/lostcancel.go
 


### PR DESCRIPTION
This PR enables [dupword](https://golangci-lint.run/usage/linters/#dupword) linter and fixes up issue:

```
❯ golangci-lint run
spancheck.go:80:1: Duplicate words (the) found (dupword)
// runFunc checks if the the node is a function, has a span, and the span never has SetStatus set.
^
```