### PR TITLE
Replace stretchr/testify with self-written asserts

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -3,8 +3,6 @@ package spancheck
 import (
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func Test_parseChecks(t *testing.T) {
@@ -32,10 +30,16 @@ func Test_parseChecks(t *testing.T) {
 		flag, tc := flag, tc
 		t.Run(flag, func(t *testing.T) {
 			t.Parallel()
-			r := require.New(t)
-
 			checks := parseChecks(strings.Split(flag, ","))
-			r.Equal(tc.checks, checks)
+			if len(checks) != len(tc.checks) {
+				t.Fatalf("Unexpected checks length=%d, want=%d", len(checks), len(tc.checks))
+			}
+			for i, check := range tc.checks {
+				want := tc.checks[i]
+				if check != want {
+					t.Fatalf("Unexpected check=%+v, want=%+v", check, want)
+				}
+			}
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,6 @@ module github.com/jjti/go-spancheck
 
 go 1.20
 
-require (
-	github.com/stretchr/testify v1.8.4
-	golang.org/x/tools v0.16.1
-)
+require golang.org/x/tools v0.16.1
 
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+require golang.org/x/mod v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,5 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
 golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
 golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR removes the dependency `github.com/stretchr/testify`. It's used only in `config_test.go` and no need to include the whole powerful package for using only one function `require.Equal`.