### PR TITLE
Add support for "Start" utility methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,9 @@ linters-settings:
     # Default: []
     ignore-check-signatures:
       - "telemetry.RecordError"
-    # A list of regexes for additional function signatures that should be considered when
-    # evaluating if a function is creating a span. This is useful if you have created utility
-    # methods to create spans, instead of calling the library's `StartSpan` function directly.
-    #
-    # Each entry should be of the form <regex>:<telemetry-type>, where `telemetry-type` can be `opentelemetry` or `opencensus`.
+    # A list of regexes for additional function signatures that create spans. This is useful if you have a utility
+    # method to create spans. Each entry should be of the form <regex>:<telemetry-type>, where `telemetry-type`
+    # can be `opentelemetry` or `opencensus`.
     # https://github.com/jjti/go-spancheck#extra-start-span-signatures
     # Default: []
     extra-start-span-signatures:
@@ -134,17 +132,17 @@ spancheck -checks 'end,set-status,record-error' -ignore-check-signatures 'record
 
 ### Extra Start Span Signatures
 
-By default, Span creation will be tracked from direct calls to [(go.opentelemetry.io/otel/trace.Tracer).Start](https://github.com/open-telemetry/opentelemetry-go/blob/98b32a6c3a87fbee5d34c063b9096f416b250897/trace/trace.go#L523), [go.opencensus.io/trace.StartSpan](https://pkg.go.dev/go.opencensus.io/trace#StartSpan), and [go.opencensus.io/trace.StartSpanWithRemoteParent](https://github.com/census-instrumentation/opencensus-go/blob/v0.24.0/trace/trace_api.go#L66). If you have created a utility function to call these, then only your function will be analyzed. In addition, this function will be flagged as not calling `span.End()`, as it effectively leaks the span.
+By default, Span creation will be tracked from calls to [(go.opentelemetry.io/otel/trace.Tracer).Start](https://github.com/open-telemetry/opentelemetry-go/blob/98b32a6c3a87fbee5d34c063b9096f416b250897/trace/trace.go#L523), [go.opencensus.io/trace.StartSpan](https://pkg.go.dev/go.opencensus.io/trace#StartSpan), or [go.opencensus.io/trace.StartSpanWithRemoteParent](https://github.com/census-instrumentation/opencensus-go/blob/v0.24.0/trace/trace_api.go#L66).
 
-For these functions, you can use the `-extra-start-span-signatures` argument to indicate that these functions are creating spans.
+You can use the `-extra-start-span-signatures` flag to list additional Span creation functions. For all such functions:
 
-You must pass a comma-separated list of regex patterns, and the telemetry library the function is returning a span for.
-Each entry should be of the form `<regex>:<telemetry-type>`, where `telemetry-type` can be `opentelemetry` or `opencensus`.
+1. their Spans will be linted (for all enable checks)
+1. checks will be disabled (i.e. there is no linting of Spans within the creation functions)
 
-For example, if you have created a function named `Start` under the `telemetry/trace` package, using the `go.opentelemetry.io/otel` library, you can include this function for analysis like so:
+You must pass a comma-separated list of regex patterns and the telemetry library corresponding to the returned Span. Each entry should be of the form `<regex>:<telemetry-type>`, where `telemetry-type` can be `opentelemetry` or `opencensus`. For example, if you have created a function named `StartTrace` in a `telemetry` package, using the `go.opentelemetry.io/otel` library, you can include this function for analysis like so:
 
 ```bash
-spancheck -extra-start-span-signatures 'github.com/user/repo/telemetry/trace.Start:opentelemetry' ./...
+spancheck -extra-start-span-signatures 'github.com/user/repo/telemetry/StartTrace:opentelemetry' ./...
 ```
 
 ## Problem Statement

--- a/cmd/spancheck/main.go
+++ b/cmd/spancheck/main.go
@@ -23,11 +23,17 @@ func main() {
 	// Set the list of function signatures to ignore checks for.
 	ignoreCheckSignatures := ""
 	flag.StringVar(&ignoreCheckSignatures, "ignore-check-signatures", "", "comma-separated list of regex for function signatures that disable checks on errors")
+
+	extraStartSpanSignatures := ""
+	flag.StringVar(&extraStartSpanSignatures, "extra-start-span-signatures", "", "comma-separated list of regex:telemetry-type for function signatures that indicate the start of a span")
+
 	flag.Parse()
 
 	cfg := spancheck.NewDefaultConfig()
 	cfg.EnabledChecks = strings.Split(checkStrings, ",")
 	cfg.IgnoreChecksSignaturesSlice = strings.Split(ignoreCheckSignatures, ",")
+
+	cfg.StartSpanMatchersSlice = append(cfg.StartSpanMatchersSlice, strings.Split(extraStartSpanSignatures, ",")...)
 
 	singlechecker.Main(spancheck.NewAnalyzerWithConfig(cfg))
 }

--- a/config.go
+++ b/config.go
@@ -167,8 +167,7 @@ func (c *Config) parseStartSpanSignatures() {
 		})
 
 		if i >= len(defaultStartSpanSignatures) {
-			cols := strings.Split(sig, ":")
-			customMatchers = append(customMatchers, cols[len(cols)-1])
+			customMatchers = append(customMatchers, sig)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -148,7 +148,8 @@ func (c *Config) parseStartSpanSignatures() {
 				validSpanTypes = append(validSpanTypes, k)
 			}
 
-			log.Default().Printf("[WARN] invalid start span type \"%s\". expected one of %s\n", sigType, strings.Join(validSpanTypes, ", "))
+			log.Default().
+				Printf("[WARN] invalid start span type \"%s\". expected one of %s\n", sigType, strings.Join(validSpanTypes, ", "))
 
 			continue
 		}
@@ -166,7 +167,7 @@ func (c *Config) parseStartSpanSignatures() {
 		})
 
 		if i >= len(defaultStartSpanSignatures) {
-			cols := strings.Split(sig, ".")
+			cols := strings.Split(sig, ":")
 			customMatchers = append(customMatchers, cols[len(cols)-1])
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -135,6 +135,11 @@ func (c *Config) parseStartSpanSignatures() {
 		}
 
 		sig, sigType := parts[0], parts[1]
+		if len(sig) < 1 {
+			log.Default().Print("[WARN] invalid start span signature, empty pattern")
+
+			continue
+		}
 
 		spanType, ok := SpanTypes[sigType]
 		if !ok {
@@ -161,20 +166,12 @@ func (c *Config) parseStartSpanSignatures() {
 		})
 
 		if i >= len(defaultStartSpanSignatures) {
-			customMatchers = append(customMatchers, sig)
+			cols := strings.Split(sig, ".")
+			customMatchers = append(customMatchers, cols[len(cols)-1])
 		}
 	}
 
-	if len(customMatchers) == 0 {
-		return
-	}
-
-	customStartRegex, err := regexp.Compile(fmt.Sprintf("(%s)", strings.Join(customMatchers, "|")))
-	if err != nil {
-		log.Default().Printf("[WARN] failed to compile regex from combo of customer start signatures %v: %v\n", customMatchers, err)
-	} else {
-		c.startSpanMatchersCustomRegex = customStartRegex
-	}
+	c.startSpanMatchersCustomRegex = createRegex(customMatchers)
 }
 
 func parseChecks(checksSlice []string) []Check {

--- a/config.go
+++ b/config.go
@@ -22,6 +22,15 @@ const (
 	RecordErrorCheck
 )
 
+var DefaultStartSpanSignatures = []string{
+	// https://github.com/open-telemetry/opentelemetry-go/blob/98b32a6c3a87fbee5d34c063b9096f416b250897/trace/trace.go#L523
+	`(\(go.opentelemetry.io/otel/trace.Tracer\).Start):opentelemetry`,
+	// https://pkg.go.dev/go.opencensus.io/trace#StartSpan
+	`(go.opencensus.io/trace.StartSpan):opencensus`,
+	// https://github.com/census-instrumentation/opencensus-go/blob/v0.24.0/trace/trace_api.go#L66
+	`(go.opencensus.io/trace.StartSpanWithRemoteParent):opencensus`,
+}
+
 func (c Check) String() string {
 	switch c {
 	case EndCheck:
@@ -35,14 +44,17 @@ func (c Check) String() string {
 	}
 }
 
-var (
-	// Checks is a list of all checks by name.
-	Checks = map[string]Check{
-		EndCheck.String():         EndCheck,
-		SetStatusCheck.String():   SetStatusCheck,
-		RecordErrorCheck.String(): RecordErrorCheck,
-	}
-)
+// Checks is a list of all checks by name.
+var Checks = map[string]Check{
+	EndCheck.String():         EndCheck,
+	SetStatusCheck.String():   SetStatusCheck,
+	RecordErrorCheck.String(): RecordErrorCheck,
+}
+
+type spanStartMatcher struct {
+	signature *regexp.Regexp
+	spanType  spanType
+}
 
 // Config is a configuration for the spancheck analyzer.
 type Config struct {
@@ -55,6 +67,8 @@ type Config struct {
 	// the IgnoreSetStatusCheckSignatures regex.
 	IgnoreChecksSignaturesSlice []string
 
+	StartSpanMatchersSlice []string
+
 	endCheckEnabled    bool
 	setStatusEnabled   bool
 	recordErrorEnabled bool
@@ -62,12 +76,15 @@ type Config struct {
 	// ignoreChecksSignatures is a regex that, if matched, disables the
 	// SetStatus and RecordError checks on error.
 	ignoreChecksSignatures *regexp.Regexp
+
+	startSpanMatchers []spanStartMatcher
 }
 
 // NewDefaultConfig returns a new Config with default values.
 func NewDefaultConfig() *Config {
 	return &Config{
-		EnabledChecks: []string{EndCheck.String()},
+		EnabledChecks:          []string{EndCheck.String()},
+		StartSpanMatchersSlice: DefaultStartSpanSignatures,
 	}
 }
 
@@ -83,12 +100,60 @@ func (c *Config) finalize() {
 
 // parseSignatures sets the Ignore*CheckSignatures regex from the string slices.
 func (c *Config) parseSignatures() {
+	c.parseIgnoreSignatures()
+	c.parseStartSpanSignatures()
+}
+
+func (c *Config) parseIgnoreSignatures() {
 	if c.ignoreChecksSignatures == nil && len(c.IgnoreChecksSignaturesSlice) > 0 {
 		if len(c.IgnoreChecksSignaturesSlice) == 1 && c.IgnoreChecksSignaturesSlice[0] == "" {
 			return
 		}
 
 		c.ignoreChecksSignatures = createRegex(c.IgnoreChecksSignaturesSlice)
+	}
+}
+
+func (c *Config) parseStartSpanSignatures() {
+	if c.startSpanMatchers != nil {
+		return
+	}
+
+	for _, sig := range c.StartSpanMatchersSlice {
+		parts := strings.Split(sig, ":")
+
+		//nolint:gomnd // Make sure we have both a signature and a telemetry type
+		if len(parts) != 2 {
+			log.Default().Printf("[WARN] invalid start span signature \"%s\". expected regex:telemetry-type\n", sig)
+
+			continue
+		}
+
+		sig, sigType := parts[0], parts[1]
+
+		spanType, ok := SpanTypes[sigType]
+		if !ok {
+			validSpanTypes := make([]string, 0, len(SpanTypes))
+			for k := range SpanTypes {
+				validSpanTypes = append(validSpanTypes, k)
+			}
+
+			log.Default().Printf("[WARN] invalid start span type \"%s\". expected one of %s", sigType, strings.Join(validSpanTypes, ", "))
+
+			continue
+		}
+
+		regex, err := regexp.Compile(sig)
+		if err != nil {
+			log.Default().Printf("[WARN] failed to compile regex from signature %s: %v\n", sig, err)
+
+			continue
+		}
+
+		c.startSpanMatchers = append(c.startSpanMatchers, spanStartMatcher{
+			signature: regex,
+			spanType:  spanType,
+		})
 	}
 }
 

--- a/spancheck.go
+++ b/spancheck.go
@@ -88,9 +88,10 @@ func runFunc(pass *analysis.Pass, node ast.Node, config *Config) {
 		funcScope = pass.TypesInfo.Scopes[v.Type]
 	case *ast.FuncDecl:
 		funcScope = pass.TypesInfo.Scopes[v.Type]
+		fnSig := pass.TypesInfo.ObjectOf(v.Name).String()
 
 		// Skip checking spans in this function if it's a custom starter/creator.
-		if config.startSpanMatchersCustomRegex != nil && config.startSpanMatchersCustomRegex.MatchString(v.Name.Name) {
+		if config.startSpanMatchersCustomRegex != nil && config.startSpanMatchersCustomRegex.MatchString(fnSig) {
 			return
 		}
 	}
@@ -330,7 +331,15 @@ outer:
 }
 
 // usesCall reports whether stmts contain a use of the selName call on variable v.
-func usesCall(pass *analysis.Pass, stmts []ast.Node, sv spanVar, selName string, ignoreCheckSig *regexp.Regexp, startSpanMatchers []spanStartMatcher, depth int) bool {
+func usesCall(
+	pass *analysis.Pass,
+	stmts []ast.Node,
+	sv spanVar,
+	selName string,
+	ignoreCheckSig *regexp.Regexp,
+	startSpanMatchers []spanStartMatcher,
+	depth int,
+) bool {
 	if depth > 1 { // for perf reasons, do not dive too deep thru func literals, just one level deep check.
 		return false
 	}

--- a/spancheck_test.go
+++ b/spancheck_test.go
@@ -33,6 +33,10 @@ func Test(t *testing.T) {
 				spancheck.RecordErrorCheck.String(),
 				spancheck.SetStatusCheck.String(),
 			}
+			cfg.StartSpanMatchersSlice = append(cfg.StartSpanMatchersSlice,
+				"util.TestStartTrace:opentelemetry",
+				"testStartTrace:opencensus",
+			)
 
 			return cfg
 		},

--- a/spancheck_test.go
+++ b/spancheck_test.go
@@ -35,7 +35,7 @@ func Test(t *testing.T) {
 			}
 			cfg.StartSpanMatchersSlice = append(cfg.StartSpanMatchersSlice,
 				"util.TestStartTrace:opentelemetry",
-				"testStartTrace:opencensus",
+				"enableall.testStartTrace:opencensus",
 			)
 
 			return cfg

--- a/spancheck_test.go
+++ b/spancheck_test.go
@@ -11,27 +11,35 @@ import (
 func Test(t *testing.T) {
 	t.Parallel()
 
-	for dir, config := range map[string]*spancheck.Config{
-		"base": spancheck.NewDefaultConfig(),
-		"disableerrorchecks": {
-			EnabledChecks: []string{
+	type configFactory func() *spancheck.Config
+
+	for dir, configFactory := range map[string]configFactory{
+		"base": spancheck.NewDefaultConfig,
+		"disableerrorchecks": func() *spancheck.Config {
+			cfg := spancheck.NewDefaultConfig()
+			cfg.EnabledChecks = []string{
 				spancheck.EndCheck.String(),
 				spancheck.RecordErrorCheck.String(),
 				spancheck.SetStatusCheck.String(),
-			},
-			IgnoreChecksSignaturesSlice: []string{"telemetry.Record", "recordErr"},
+			}
+			cfg.IgnoreChecksSignaturesSlice = []string{"telemetry.Record", "recordErr"}
+
+			return cfg
 		},
-		"enableall": {
-			EnabledChecks: []string{
+		"enableall": func() *spancheck.Config {
+			cfg := spancheck.NewDefaultConfig()
+			cfg.EnabledChecks = []string{
 				spancheck.EndCheck.String(),
 				spancheck.RecordErrorCheck.String(),
 				spancheck.SetStatusCheck.String(),
-			},
+			}
+
+			return cfg
 		},
 	} {
 		dir := dir
 		t.Run(dir, func(t *testing.T) {
-			analysistest.Run(t, "testdata/"+dir, spancheck.NewAnalyzerWithConfig(config))
+			analysistest.Run(t, "testdata/"+dir, spancheck.NewAnalyzerWithConfig(configFactory()))
 		})
 	}
 }

--- a/testdata/enableall/enable_all.go
+++ b/testdata/enableall/enable_all.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jjti/go-spancheck/testdata/enableall/util"
 	"go.opencensus.io/trace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -155,6 +156,11 @@ func _() error {
 	return nil
 }
 
+func _() {
+	span := util.TestStartTrace() // want "span.End is not called on all paths, possible memory leak"
+	fmt.Print(span)
+} // want "return can be reached without calling span.End"
+
 // correct
 
 func _() error {
@@ -201,4 +207,9 @@ func _() {
 
 	_, span = otel.Tracer("foo").Start(context.Background(), "bar")
 	defer span.End()
+}
+
+func testStartTrace() *trace.Span { // no error expected because this is in extra start types
+	_, span := trace.StartSpan(context.Background(), "bar")
+	return span
 }

--- a/testdata/enableall/util/start_tracer.go
+++ b/testdata/enableall/util/start_tracer.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestStartTrace() trace.Span {
+	_, span := otel.Tracer("foo").Start(context.Background(), "bar")
+	return span
+}


### PR DESCRIPTION
Fixes https://github.com/jjti/go-spancheck/issues/7.

Replaces the list of names and packages for the Start span functions with a list of regex patterns that may be extended using the `-extra-start-span-signatures` command line option.

The format is `<regex>:<telemetry-type>`. Ideally this would just be a list of regex patterns, but we need to know what telemetry library we're matching against so we don't run RecordError on opencensus.

I've tested this on our rather large code base, and was pleased to see many new lints that we had previously missed after moving to a utility method. 

This is a great lint check, thank you!