### PR TITLE
Fix start span matchers slice flag

### DIFF
--- a/cmd/spancheck/main.go
+++ b/cmd/spancheck/main.go
@@ -33,7 +33,9 @@ func main() {
 	cfg.EnabledChecks = strings.Split(checkStrings, ",")
 	cfg.IgnoreChecksSignaturesSlice = strings.Split(ignoreCheckSignatures, ",")
 
-	cfg.StartSpanMatchersSlice = append(cfg.StartSpanMatchersSlice, strings.Split(extraStartSpanSignatures, ",")...)
+	if extraStartSpanSignatures != "" {
+		cfg.StartSpanMatchersSlice = append(cfg.StartSpanMatchersSlice, strings.Split(extraStartSpanSignatures, ",")...)
+	}
 
 	singlechecker.Main(spancheck.NewAnalyzerWithConfig(cfg))
 }


### PR DESCRIPTION
Fixing this flag being set to an empty string:

```bash
# josh @ M-FTQC4VW0R3 in ~/jjti/go-spancheck/testdata/base on git:main o [19:12:04] 
$ spancheck ./...    
2024/04/22 19:12:10 [WARN] invalid start span signature "". expected regex:telemetry-type
/Users/josh/jjti/go-spancheck/testdata/base/base.go:22:2: span is unassigned, probable memory leak
/Users/josh/jjti/go-spancheck/testdata/base/base.go:23:7: span is unassigned, probable memory leak
/Users/josh/jjti/go-spancheck/testdata/base/base.go:28:2: span.End is not called on all paths, possible memory leak
/Users/josh/jjti/go-spancheck/testdata/base/base.go:30:1: return can be reached without calling span.End
```