### PR TITLE
Fix nilptr crash in usesCall

### DIFF
--- a/spancheck.go
+++ b/spancheck.go
@@ -389,7 +389,7 @@ func usesCall(
 				// Selector (End, SetStatus, RecordError) hit.
 				if n.Sel.Name == selName {
 					id, ok := n.X.(*ast.Ident)
-					found = ok && id.Obj.Decl == sv.id.Obj.Decl
+					found = ok && id.Obj != nil && id.Obj.Decl == sv.id.Obj.Decl
 				}
 
 				// Check if an ignore signature matches.


### PR DESCRIPTION
In `usesCall()`, there are circumstances where the `ast.Ident` doesn't have an `Obj` instance, but the line `found = ok && id.Obj.Decl == sv.id.Obj.Decl` assumes that it it will always have an instance.

I couldn't find an obvious pattern that explains when this happens, but it happens often enough in our code base that I figured I'd just add a nilptr check on the expression.