### PR TITLE
Check all branches for end in defer

### DIFF
--- a/spancheck.go
+++ b/spancheck.go
@@ -405,8 +405,7 @@ func usesCall(
 				}
 
 				if g := cfgs.FuncLit(f); g != nil && len(g.Blocks) > 0 {
-					switch selName {
-					case selNameEnd:
+					if selName == selNameEnd {
 						// Check if all returning blocks call end.
 						for _, b := range g.Blocks {
 							if b.Return() != nil && !usesCall(
@@ -424,20 +423,20 @@ func usesCall(
 
 						found = true
 						return false
-					case selNameSetStatus, selNameRecordError:
-						for _, b := range g.Blocks {
-							if usesCall(
-								pass,
-								b.Nodes,
-								sv,
-								selName,
-								ignoreCheckSig,
-								startSpanMatchers,
-								depth+1,
-							) {
-								found = true
-								return false
-							}
+					}
+
+					for _, b := range g.Blocks {
+						if usesCall(
+							pass,
+							b.Nodes,
+							sv,
+							selName,
+							ignoreCheckSig,
+							startSpanMatchers,
+							depth+1,
+						) {
+							found = true
+							return false
 						}
 					}
 				}

--- a/spancheck.go
+++ b/spancheck.go
@@ -23,6 +23,12 @@ const (
 	spanOpenCensus                    // from go.opencensus.io/trace
 )
 
+const (
+	selNameEnd         = "End"
+	selNameSetStatus   = "SetStatus"
+	selNameRecordError = "RecordError"
+)
+
 // SpanTypes is a list of all span types by name.
 var SpanTypes = map[string]spanType{
 	"opentelemetry": spanOpenTelemetry,
@@ -183,7 +189,7 @@ func runFunc(pass *analysis.Pass, node ast.Node, config *Config) {
 	for _, sv := range spanVars {
 		if config.endCheckEnabled {
 			// Check if there's no End to the span.
-			if ret := getMissingSpanCalls(pass, g, sv, "End", func(_ *analysis.Pass, ret *ast.ReturnStmt) *ast.ReturnStmt { return ret }, nil, config.startSpanMatchers); ret != nil {
+			if ret := getMissingSpanCalls(pass, g, sv, selNameEnd, func(_ *analysis.Pass, ret *ast.ReturnStmt) *ast.ReturnStmt { return ret }, nil, config.startSpanMatchers); ret != nil {
 				pass.ReportRangef(sv.stmt, "%s.End is not called on all paths, possible memory leak", sv.vr.Name())
 				pass.ReportRangef(ret, "return can be reached without calling %s.End", sv.vr.Name())
 			}
@@ -191,7 +197,7 @@ func runFunc(pass *analysis.Pass, node ast.Node, config *Config) {
 
 		if config.setStatusEnabled {
 			// Check if there's no SetStatus to the span setting an error.
-			if ret := getMissingSpanCalls(pass, g, sv, "SetStatus", getErrorReturn, config.ignoreChecksSignatures, config.startSpanMatchers); ret != nil {
+			if ret := getMissingSpanCalls(pass, g, sv, selNameSetStatus, getErrorReturn, config.ignoreChecksSignatures, config.startSpanMatchers); ret != nil {
 				pass.ReportRangef(sv.stmt, "%s.SetStatus is not called on all paths", sv.vr.Name())
 				pass.ReportRangef(ret, "return can be reached without calling %s.SetStatus", sv.vr.Name())
 			}
@@ -199,7 +205,7 @@ func runFunc(pass *analysis.Pass, node ast.Node, config *Config) {
 
 		if config.recordErrorEnabled && sv.spanType == spanOpenTelemetry { // RecordError only exists in OpenTelemetry
 			// Check if there's no RecordError to the span setting an error.
-			if ret := getMissingSpanCalls(pass, g, sv, "RecordError", getErrorReturn, config.ignoreChecksSignatures, config.startSpanMatchers); ret != nil {
+			if ret := getMissingSpanCalls(pass, g, sv, selNameRecordError, getErrorReturn, config.ignoreChecksSignatures, config.startSpanMatchers); ret != nil {
 				pass.ReportRangef(sv.stmt, "%s.RecordError is not called on all paths", sv.vr.Name())
 				pass.ReportRangef(ret, "return can be reached without calling %s.RecordError", sv.vr.Name())
 			}
@@ -216,7 +222,7 @@ func isSpanStart(info *types.Info, n ast.Node, startSpanMatchers []spanStartMatc
 
 	fnSig := info.ObjectOf(sel.Sel).String()
 
-	// Check if the function is a span start function
+	// Check if the function is a span start function.
 	for _, matcher := range startSpanMatchers {
 		if matcher.signature.MatchString(fnSig) {
 			return matcher.spanType, true
@@ -399,18 +405,39 @@ func usesCall(
 				}
 
 				if g := cfgs.FuncLit(f); g != nil && len(g.Blocks) > 0 {
-					for _, b := range g.Blocks {
-						if usesCall(
-							pass,
-							b.Nodes,
-							sv,
-							selName,
-							ignoreCheckSig,
-							startSpanMatchers,
-							depth+1,
-						) {
-							found = true
-							return false
+					switch selName {
+					case selNameEnd:
+						// Check if all returning blocks call end.
+						for _, b := range g.Blocks {
+							if b.Return() != nil && !usesCall(
+								pass,
+								b.Nodes,
+								sv,
+								selName,
+								ignoreCheckSig,
+								startSpanMatchers,
+								depth+1,
+							) {
+								return false
+							}
+						}
+
+						found = true
+						return false
+					case selNameSetStatus, selNameRecordError:
+						for _, b := range g.Blocks {
+							if usesCall(
+								pass,
+								b.Nodes,
+								sv,
+								selName,
+								ignoreCheckSig,
+								startSpanMatchers,
+								depth+1,
+							) {
+								found = true
+								return false
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Hi, 
Regarding the fix for https://github.com/jjti/go-spancheck/issues/24, I found that it can cause some false negatives, which happen fairly often.

e.g.:

```go
func func1() (err error) {
	_, span := otel.Tracer("foo").Start(context.Background(), "bar")
	defer func() {
		if err != nil {
			span.RecordError(err)
			span.SetStatus(codes.Error, "test")
			span.End() // mistakenly putting the end call inside the if block, probably due to IDE suggestions.
		}
	}()

	return errors.New("test")
}
```

This PR adds a check across all return branches for the span.End() call to help reduce these false negatives.
